### PR TITLE
Add project url to csproj file.

### DIFF
--- a/src/NewsletterSub.csproj
+++ b/src/NewsletterSub.csproj
@@ -14,6 +14,8 @@
     <NeutralLanguage>en</NeutralLanguage>
     <Description>A very simple newsletter subscription service for ASP.NET Core, which provides functionality to manage and maintain a collection of contacts and newsletter subscribers.</Description>
     <PackageTags>aspnetcore;newsletter;service;dotnetcore;efcore</PackageTags>
+    <PackageProjectUrl>https://github.com/jgdevlabs/newslettersub</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/jgdevlabs/newslettersub</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
Added additional metadata to the csproj file, which we want to have when publishing the first version to NuGet.